### PR TITLE
Updated save format

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeDatabase.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeDatabase.java
@@ -109,9 +109,10 @@ public class TradeDatabase {
     public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
         nbt.setInteger("version", this.version);
         NBTTagList tgList = new NBTTagList();
-        for (TradeGroup tg : tradeGroups.values()) {
-            tgList.appendTag(tg.writeToNBT(new NBTTagCompound()));
-        }
+        tradeGroups.values()
+            .stream()
+            .sorted(Comparator.comparing(TradeGroup::getId))
+            .forEach(tg -> tgList.appendTag(tg.writeToNBT(new NBTTagCompound())));
         nbt.setTag("tradeGroups", tgList);
         return nbt;
     }

--- a/src/main/java/com/cubefury/vendingmachine/util/NBTConverter.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/NBTConverter.java
@@ -176,20 +176,11 @@ public class NBTConverter {
             out.endArray();
         } else if (value instanceof NBTTagList) {
             List<NBTBase> tagList = getTagList((NBTTagList) value);
-            if (format) {
-                out.beginObject();
-                for (int i = 0; i < tagList.size(); i++) {
-                    NBTBase tag = tagList.get(i);
-                    out.name(i + ":" + tag.getId());
-                    NBTtoJSON_Base(tag, true, out);
-                }
-                out.endObject();
-            } else {
-                out.beginArray();
-                for (NBTBase tag : tagList) {
-                    NBTtoJSON_Base(tag, false, out);
-                }
+            out.beginArray();
+            for (NBTBase tag : tagList) {
+                NBTtoJSON_Base(tag, format, out);
             }
+            out.endArray();
         } else if (value instanceof NBTTagCompound) {
             NBTtoJSON_Compound((NBTTagCompound) value, out, format);
         } else {
@@ -233,31 +224,15 @@ public class NBTConverter {
         } else if (tag instanceof NBTTagCompound) {
             return NBTtoJSON_Compound((NBTTagCompound) tag, new JsonObject(), format);
         } else if (tag instanceof NBTTagList) {
-            if (format) {
-                JsonObject jAry = new JsonObject();
+            JsonArray jAry = new JsonArray();
 
-                List<NBTBase> tagList = getTagList((NBTTagList) tag);
+            List<NBTBase> tagList = getTagList((NBTTagList) tag);
 
-                for (int i = 0; i < tagList.size(); i++) {
-                    jAry.add(
-                        i + ":"
-                            + tagList.get(i)
-                                .getId(),
-                        NBTtoJSON_Base(tagList.get(i), true));
-                }
-
-                return jAry;
-            } else {
-                JsonArray jAry = new JsonArray();
-
-                List<NBTBase> tagList = getTagList((NBTTagList) tag);
-
-                for (NBTBase t : tagList) {
-                    jAry.add(NBTtoJSON_Base(t, false));
-                }
-
-                return jAry;
+            for (NBTBase t : tagList) {
+                jAry.add(NBTtoJSON_Base(t, format));
             }
+
+            return jAry;
         } else if (tag instanceof NBTTagByteArray) {
             JsonArray jAry = new JsonArray();
 


### PR DESCRIPTION
Now sorts by tradegroup id before writing to file, and does not add indices for NBTTagList.

This change ensures that changelogs won't be massive every time a new trade is added, from all the tradegroups and their indices getting shuffled around. The change only affects newly written files, and does not break reading legacy files.