### PR TITLE
Fixed Coins leaking into SP

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/handlers/SaveLoadHandler.java
+++ b/src/main/java/com/cubefury/vendingmachine/handlers/SaveLoadHandler.java
@@ -48,6 +48,8 @@ public class SaveLoadHandler {
 
         createFilesAndDirectories();
 
+        unloadAll();
+
         loadDatabase();
         loadTradeState();
         loadNames();

--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeDatabase.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeDatabase.java
@@ -41,6 +41,7 @@ public class TradeDatabase {
 
     public void clearTradeState(UUID player) {
         tradeGroups.forEach((k, v) -> v.clearTradeState(player));
+        TradeManager.INSTANCE.clearCurrency(player);
     }
 
     public TradeGroup getTradeGroupFromId(UUID tgId) {

--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
@@ -105,14 +105,7 @@ public class TradeManager {
     public void populateCurrencyFromNBT(NBTTagCompound nbt, UUID player, boolean merge) {
         NBTTagList tagList = nbt.getTagList("playerCurrency", Constants.NBT.TAG_COMPOUND);
         if (!merge) {
-            if (player == null) {
-                this.playerCurrency.clear();
-                this.invalidCurrency.clear();
-            } else {
-                this.playerCurrency.remove(player);
-                this.invalidCurrency.remove(player);
-            }
-
+            this.clearCurrency(player);
         }
         this.playerCurrency.computeIfAbsent(player, k -> new HashMap<>());
         for (int i = 0; i < tagList.tagCount(); i++) {
@@ -184,5 +177,15 @@ public class TradeManager {
                         .get(mapped.type) + mapped.value);
         }
         this.hasCurrencyUpdate = true;
+    }
+
+    public void clearCurrency(UUID player) {
+        if (player == null) {
+            this.playerCurrency.clear();
+            this.invalidCurrency.clear();
+        } else {
+            this.playerCurrency.remove(player);
+            this.invalidCurrency.remove(player);
+        }
     }
 }

--- a/src/main/java/com/cubefury/vendingmachine/util/JsonHelper.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/JsonHelper.java
@@ -50,7 +50,6 @@ public class JsonHelper {
 
     public static void populateTradeDatabaseFromFile(File file) {
         TradeDatabase db = TradeDatabase.INSTANCE;
-        db.clear();
 
         Function<File, NBTTagCompound> readNbt = f -> NBTConverter
             .JSONtoNBT_Object(FileIO.ReadFromFile(f), new NBTTagCompound(), true);
@@ -59,8 +58,6 @@ public class JsonHelper {
     }
 
     public static void populateTradeStateFromFiles(List<File> files) {
-        TradeDatabase db = TradeDatabase.INSTANCE;
-        db.clearTradeState(null);
         files.forEach(JsonHelper::populateTradeStateFromFile);
     }
 
@@ -71,7 +68,6 @@ public class JsonHelper {
     }
 
     public static void populateNameCacheFromFile(File file) {
-        NameCache.INSTANCE.clear();
         JsonObject json = FileIO.ReadFromFile(file);
 
         NBTTagCompound nbt = NBTConverter.JSONtoNBT_Object(json, new NBTTagCompound(), true);


### PR DESCRIPTION
Fixes #25.

There was an issue where the coins data was not reset upon loading up a world. This was causing the locally stored data from a server session to persist if a player played on a MP world, leaves, then opens up a SP world where there was no prior currency data (eg. creating a new world).

**This PR centralizes the unloading of everything on server start and loading data from scratch.**

The data leak technically still happens if a player hops from one MP server to another, but it does not affect gameplay nor spawns in items in this case. Since coins are server-side authoritative, there is no risk of the coins being transferred there. When a player opens a vending machine for the first time on another server, it would immediately sync and override the local coin data.

I acknowledge this fix is not very clean, but it will fix the issue for now. The immediate next steps I'm working on are to change the coin sync code to decouple it from tradestate as much as possible and just sync the coin display amount via MUI2 synchandlers instead of sending/updating the coin amounts to the client. When that happens, this leak will stop happening altogether.

Tested on 186 in both SP and local MP with multiple players, to ensure read/write and integrity of saved coin data (to prevent another coin disappearance incident).