### PR TITLE
Fix tile data saving

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -236,6 +236,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         }
         ticksSinceOutput = this.newBufferedOutputs ? 0 : ticksSinceOutput + 1;
         this.newBufferedOutputs = false;
+        this.markDirty();
     }
 
     private boolean processTradeOnServer(TradeRequest tradeRequest) {
@@ -331,6 +332,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
             .get(tradeRequest.tradeGroup)
             .executeTrade(tradeRequest.playerID);
         this.sendTradeUpdate();
+        this.markDirty();
         return true;
     }
 

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -429,6 +429,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                             if (hasCoin) {
                                 this.refreshInputSlots();
                             }
+                            base.markDirty();
                         }));
             })
             .build();
@@ -440,7 +441,8 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
             .key('I', index -> {
                 return new ItemSlot().slot(
                     new ModularSlot(base.outputItems, index).accessibility(false, true)
-                        .slotGroup("outputSlotGroup"));
+                        .slotGroup("outputSlotGroup")
+                        .changeListener((newitem, onlyAmountChanged, client, init) -> { base.markDirty(); }));
             })
             .build();
     }


### PR DESCRIPTION
Currently, the tile isn't marked for saving when the slot contents changed, potentially causing items to go missing or items to dupe if the server closes too soon after interacting with the vending machine.

This PR aims to fix this by marking the tile as dirty to minecraft anytime the inventory changes, or when the internal item dispensing buffer changes.