### PR TITLE
Increased slot count to 8

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -335,7 +335,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
     private IWidget createIOColumn() {
         return new ParentWidget<>().excludeAreaInRecipeViewer()
             .width(50)
-            .height(178)
+            .height(214)
             .right(-48)
             .top(40)
             .widgetTheme(WidgetThemes.BACKGROUND_SIDEPANEL)
@@ -349,7 +349,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                     .child(
                         new Row().child(createInputSlots().center())
                             .top(20)
-                            .height(18 * 3))
+                            .height(18 * 4))
                     .child(
                         new Row().child(
                             new ToggleButton().overlay(GTGuiTextures.OVERLAY_BUTTON_CYCLIC)
@@ -363,24 +363,24 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                                     .tooltipBuilder(t -> t.addLine(IKey.lang("vendingmachine.gui.coin_eject")))
                                     .syncHandler("ejectCoins")
                                     .left(6))
-                            .top(80)
+                            .top(98)
                             .height(18))
                     .child(
                         GuiTextures.OUTPUT_SPRITE.asWidget()
                             .leftRel(0.5f)
-                            .bottom(52)
+                            .bottom(70)
                             .width(30)
                             .height(20))
                     .child(
                         new Row().child(createOutputSlots().center())
                             .bottom(6)
-                            .height(18 * 3))
+                            .height(18 * 4))
                     .right(1));
     }
 
     private SlotGroupWidget createInputSlots() {
         return SlotGroupWidget.builder()
-            .matrix("II", "II", "II")
+            .matrix("II", "II", "II", "II")
             .key('I', index -> {
                 InterceptingSlot slot = new InterceptingSlot(base.inputItems, index, this.base);
                 this.inputSlots.add(slot);
@@ -414,7 +414,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
 
     private SlotGroupWidget createOutputSlots() {
         return SlotGroupWidget.builder()
-            .matrix("II", "II", "II")
+            .matrix("II", "II", "II", "II")
             .key('I', index -> {
                 return new ItemSlot().slot(
                     new ModularSlot(base.outputItems, index).accessibility(false, true)


### PR DESCRIPTION
Rationale:
<img width="365" height="297" alt="image" src="https://github.com/user-attachments/assets/a77d0abc-7917-454f-a266-da1b205e13b3" />

- I've discussed this with dream to increase the slot count to 8

Changes:
- Increased I/O slot count to 8
- Added legacy migration (smoothly transition older saves with different slot counts)

Tests:
- Tested to ensure no crashes or item loss during migration of older saves
- Tested to ensure buffered outputs are maintained through migration of older saves
- Tested in both SP and MP on daily 214

Developer notes:
- There's technically a getStacks() method for the ItemHandler classes, but it has an unused annotation, so I opted not to use it in case it gets deprecated in the future.

Screenshot of new I/O:
<img width="561" height="587" alt="image" src="https://github.com/user-attachments/assets/2de66a47-7df2-4489-881b-41394aac5bce" />
