### PR TITLE
Fixed oredict crash

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/util/BigItemStack.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/BigItemStack.java
@@ -72,7 +72,7 @@ public class BigItemStack {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean hasOreDict() {
-        return !StringUtils.isNullOrEmpty(this.oreDict) && this.oreIng.getMatchingStacks().length > 0;
+        return !StringUtils.isNullOrEmpty(this.oreDict);
     }
 
     @Nonnull


### PR DESCRIPTION
Removed client-side stack matching (only used for NEI recipe display) for server-side oredict check, which caused a crash on dedicated servers.

Tested in SP + MP daily 214.