### PR TITLE
Add incomplete structure message

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -30,6 +30,7 @@ import com.cleanroommc.modularui.widgets.CycleButtonWidget;
 import com.cleanroommc.modularui.widgets.ListWidget;
 import com.cleanroommc.modularui.widgets.PagedWidget;
 import com.cleanroommc.modularui.widgets.SlotGroupWidget;
+import com.cleanroommc.modularui.widgets.TextWidget;
 import com.cleanroommc.modularui.widgets.ToggleButton;
 import com.cleanroommc.modularui.widgets.layout.Column;
 import com.cleanroommc.modularui.widgets.layout.Flow;
@@ -500,6 +501,13 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                 .collapseDisabledChild(true);
 
             tradeList.child(new Row().height(2));
+
+            // Incomplete Structure status message
+            Flow statusRow = new Row().height(10).width(TRADE_ROW_WIDTH).marginLeft(2)
+                .child(new TextWidget(IKey.lang("vendingmachine.gui.error.incomplete_structure")))
+                .setEnabledIf(slot -> !this.getBase().getActive());
+            tradeList.child(statusRow);
+
             // Higher first row top margin
             Flow row = new TradeRow().height(TILE_ITEM_HEIGHT +2).width(TRADE_ROW_WIDTH).marginLeft(2);
 

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -32,6 +32,7 @@ vendingmachine.gui.cooldown_display.minute=m
 vendingmachine.gui.cooldown_display.hour=h
 vendingmachine.gui.cooldown_display.day=d
 
+vendingmachine.gui.error.incomplete_structure=Incomplete Structure.
 vendingmachine.gui.error.player_using=Someone is using the vending machine at the moment.
 vendingmachine.chat.trade_restock=Vending Machine Restocked: %s
 


### PR DESCRIPTION
This PR adds an incomplete structure error above the trades if it's not complete (Actually just checks if the vending machine is active, which are logically equivalent checks for this multi).

Tested in daily 305 in SP and MP, updates even when someone else is accessing the GUI as shown below.

https://github.com/user-attachments/assets/f3d792ed-dbf3-4710-87cf-68be8a17ca81

