### PR TITLE
Show Structure Incomplete When Structure is Incomplete

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -102,6 +102,8 @@ public class MTEVendingMachine extends MTEMultiBlockBase
 
     public static final int MAX_TRADES = 300;
 
+    public static final int STRUCTURE_CHECK_TICKS = 20;
+
     private static final ITexture[] FACING_SIDE = {
         TextureFactory.of(Textures.BlockIcons.MACHINE_CASING_ITEM_PIPE_TIN) };
     private static final ITexture[] FACING_FRONT = { TextureFactory.of(VM_MACHINE_FRONT_OFF) };
@@ -112,6 +114,8 @@ public class MTEVendingMachine extends MTEMultiBlockBase
     protected final List<RenderOverlay.OverlayTicket> overlayTickets = new ArrayList<>();
 
     private MultiblockTooltipBuilder tooltipBuilder;
+
+    public int mUpdate = 0;
 
     private final boolean mIsAnimated;
 
@@ -611,6 +615,8 @@ public class MTEVendingMachine extends MTEMultiBlockBase
                 OverlayHelper.clearVMOverlay(overlayTickets);
             }
             return;
+        } else if (this.mUpdate++ % STRUCTURE_CHECK_TICKS == 0) {
+            this.mMachine = checkMachine(aBaseMetaTileEntity, null);
         }
         aBaseMetaTileEntity.setActive(this.mMachine);
         if (!this.mMachine) return;


### PR DESCRIPTION
Should fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23403

One consequence of this is that the overlay updates less quickly, not sure if there's a sleek way to get best of both worlds here. 

Tested on client & server