### PR TITLE
Check if player is not accessing vending machine before reloading tradestate

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/command/vending/SubCmdReload.java
+++ b/src/main/java/com/cubefury/vendingmachine/command/vending/SubCmdReload.java
@@ -60,7 +60,7 @@ public class SubCmdReload implements IVendingSubcommand {
                 ) {
                     sender.addChatMessage(
                         new ChatComponentText(
-                            "Cannot reload trade state for player currently accessing vending machine."));
+                            "Cannot reload trade state for a player currently accessing a vending machine."));
                     return;
                 }
             }


### PR DESCRIPTION
This PR serves as a follow up for the tradestate reload (#64), disallowing trade state reload for players who are currently accessing the vending machine. This is because exiting the VM UI saves the tradestate, which can create unpredictable behaviour.

<img width="868" height="74" alt="image" src="https://github.com/user-attachments/assets/0324cec4-8ef5-430e-a4d4-5282fc31a1a5" />

Tested in SP + MP in devenv.