### PR TITLE
Show trades which share a cooldown

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     implementation("com.github.GTNewHorizons:ModularUI2:2.3.39-1.7.10:dev")
     implementation("com.github.GTNewHorizons:StructureLib:1.4.28:dev")
-    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.360:dev")
+    implementation("com.github.GTNewHorizons:GT5-Unofficial:5.09.52.375:dev")
 }
 
 // deps may transitively add Baubles, so we replace it

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -49,6 +49,7 @@ import com.cubefury.vendingmachine.trade.CurrencyType;
 import com.cubefury.vendingmachine.trade.FavouritesTracker;
 import com.cubefury.vendingmachine.trade.TradeCategory;
 import com.cubefury.vendingmachine.trade.TradeDatabase;
+import com.cubefury.vendingmachine.trade.TradeGroup;
 import com.cubefury.vendingmachine.trade.TradeManager;
 import com.cubefury.vendingmachine.util.BigItemStack;
 import com.cubefury.vendingmachine.util.Translator;
@@ -67,8 +68,8 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
     private boolean ejectItems = false;
     private boolean ejectCoins = false;
     private final Map<CurrencyType, Boolean> ejectSingleCoin = new HashMap<>();
-    private final Map<TradeCategory, List<TradeItemDisplayWidget>> displayedTradesTiles = new HashMap<>();
-    private final Map<TradeCategory, List<TradeItemDisplayWidget>> displayedTradesList = new HashMap<>();
+    public final Map<TradeCategory, List<TradeItemDisplayWidget>> displayedTradesTiles = new HashMap<>();
+    public final Map<TradeCategory, List<TradeItemDisplayWidget>> displayedTradesList = new HashMap<>();
     private final List<TradeCategory> tradeCategories = new ArrayList<>();
     private final List<InterceptingSlot> inputSlots = new ArrayList<>();
 
@@ -252,6 +253,10 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
             }
         }
         return tabColumn;
+    }
+
+    public TradeCategory getActiveTradeCategory() {
+        return this.tradeCategories.get(this.tabController.getActivePageIndex());
     }
 
     // why is the original method private lmao
@@ -492,6 +497,20 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
                 }
                 builder.emptyLine();
             }
+
+            TradeGroup tg = TradeDatabase.INSTANCE.getTradeGroupFromId(cur.tgID);
+            if (
+                tg != null && tg.getTrades()
+                    .size() > 1
+            ) {
+                builder.addLine(
+                    IKey.str(
+                        Translator.translate(
+                            "vendingmachine.gui.shared_trades_tooltip",
+                            tg.getTrades()
+                                .size() - 1)));
+            }
+            builder.emptyLine();
 
             builder.addLine(
                 IKey.str(Translator.translate("vendingmachine.gui.trade_hint"))

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
@@ -95,6 +95,9 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                 if (this.display.tradeableNow) {
                     GuiDraw.drawBorderInsideLTRB(1, 1, 45, 23, 2, 0x883CFF00);
                 }
+                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
+                    GuiDraw.drawBorderInsideLTRB(1, 1, 45, 23, 1, 0xAA039BE5);
+                }
                 if (!this.checkVmActive() || this.display.hasCooldown || !this.display.enabled) {
                     GuiDraw.drawRoundedRect(
                         1,
@@ -131,6 +134,9 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                     3,
                     MTEVendingMachineGui.LIST_ITEM_HEIGHT - 3,
                     this.display.tradeableNow ? 0x883CFF00 : 0x88333333);
+                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
+                    GuiDraw.drawRect(1, 1, 2, MTEVendingMachineGui.LIST_ITEM_HEIGHT - 3, 0xAA039BE5);
+                }
                 if (!this.checkVmActive() || this.display.hasCooldown || !this.display.enabled) {
                     GuiDraw.drawRect(
                         1,

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
@@ -95,9 +95,6 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                 if (this.display.tradeableNow) {
                     GuiDraw.drawBorderInsideLTRB(1, 1, 45, 23, 2, 0x883CFF00);
                 }
-                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
-                    GuiDraw.drawBorderInsideLTRB(1, 1, 45, 23, 1, 0xAA039BE5);
-                }
                 if (!this.checkVmActive() || this.display.hasCooldown || !this.display.enabled) {
                     GuiDraw.drawRoundedRect(
                         1,
@@ -107,6 +104,9 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                         0xBB000000,
                         1,
                         1);
+                }
+                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
+                    GuiDraw.drawBorderInsideLTRB(1, 1, 45, 23, 1, 0xAA039BE5);
                 }
                 this.overlay(
                     IKey.str(display.hasCooldown ? this.display.cooldownText : "")
@@ -134,9 +134,6 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                     3,
                     MTEVendingMachineGui.LIST_ITEM_HEIGHT - 3,
                     this.display.tradeableNow ? 0x883CFF00 : 0x88333333);
-                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
-                    GuiDraw.drawRect(1, 1, 2, MTEVendingMachineGui.LIST_ITEM_HEIGHT - 3, 0xAA039BE5);
-                }
                 if (!this.checkVmActive() || this.display.hasCooldown || !this.display.enabled) {
                     GuiDraw.drawRect(
                         1,
@@ -144,6 +141,9 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
                         MTEVendingMachineGui.LIST_ITEM_WIDTH - 2,
                         MTEVendingMachineGui.LIST_ITEM_HEIGHT - 2,
                         0xBB000000);
+                }
+                if (this.display.tgID.equals(this.rootPanel.currentSelected)) {
+                    GuiDraw.drawRect(1, 1, 2, MTEVendingMachineGui.LIST_ITEM_HEIGHT - 3, 0xAA039BE5);
                 }
                 this.overlay(
                     IKey.str(display.hasCooldown && this.display.enabled ? this.display.cooldownText : "")

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeMainPanel.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeMainPanel.java
@@ -39,6 +39,7 @@ public class TradeMainPanel extends ModularPanel {
     private final PosGuiData guiData;
     private EntityPlayer player = null;
     private int ticksOpen = 0;
+    public UUID currentSelected = null;
 
     public TradeMainPanel(@NotNull String name, MTEVendingMachineGui gui, PosGuiData guiData,
         PanelSyncManager syncManager) {
@@ -129,6 +130,19 @@ public class TradeMainPanel extends ModularPanel {
             MTEVendingMachineGui.resetForceRefresh();
             TradeManager.INSTANCE.hasCurrencyUpdate = false;
         }
+        TradeCategory activeCategory = gui.getActiveTradeCategory();
+        Map<TradeCategory, List<TradeItemDisplayWidget>> displayedTrades = VMConfig.gui.display_type == DisplayType.TILE
+            ? gui.displayedTradesTiles
+            : gui.displayedTradesList;
+
+        this.currentSelected = null;
+        for (TradeItemDisplayWidget display : displayedTrades.get(activeCategory)) {
+            if (display.isBelowMouse()) {
+                this.currentSelected = display.getDisplay().tgID;
+                break;
+            }
+        }
+
         this.ticksOpen += 1;
     }
 

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -19,6 +19,7 @@ vendingmachine.gui.required_inputs=Requires:
 vendingmachine.gui.nc_inputs=Requires (Not Consumed):
 vendingmachine.gui.alternative_oredict=Accepts Oredict:
 vendingmachine.gui.nc_inputs_overlay_color=FDD835
+vendingmachine.gui.shared_trades_tooltip=Shares cooldown with %s other trade(s)
 vendingmachine.gui.trade_hint=Shift-Click to Purchase
 vendingmachine.gui.favourite_hint=Ctrl-Click to Toggle as Favourite
 vendingmachine.gui.display_mode=Display:


### PR DESCRIPTION
This PR closes #69.

Highlights trades which share a cooldown, and added a tooltip to show how many trades the selected one shares a cooldown with, if applicable.

Showcase:
https://github.com/user-attachments/assets/271b5005-7190-4e83-b3d6-30347d48e01f

Tested in SP + MP daily 428

Dev notes: 

1. I considered using a stopwatch icon over trades sharing the same cooldown, but it cluttered up the display too much and looked abit awkward on trades with no shared cooldowns.
2. I tried to use the onMouseBeginHover and LeaveHover methods for highlighting, so we didn't have to loop through every trade display widget per UI update. However, doing it this way introduced a race condition when shifting between elements in List display mode, cuz the widgets are directly adjacent to each other. The trivial fix for this (checking for whether the element is currently the one being selected before changing currentSelected) didn't work either.