### PR TITLE
chore(fix): prevent unwanted inventory hotkey caused gui close

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -817,6 +817,10 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui {
         return this.searchBar.getText();
     }
 
+    public SearchBar getSearchBar() {
+        return this.searchBar;
+    }
+
     // server-side sync for all input slots
     // during next tick after any input
     private void refreshInputSlots() {

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeMainPanel.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeMainPanel.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
@@ -51,6 +52,13 @@ public class TradeMainPanel extends ModularPanel {
 
     @Override
     public boolean onKeyPressed(char typedChar, int keyCode) {
+        int invKey = Minecraft.getMinecraft().gameSettings.keyBindInventory.getKeyCode();
+        if (
+            keyCode == invKey && gui.getSearchBar()
+                .isFocused()
+        ) {
+            return true;
+        }
         if (keyCode == Keyboard.KEY_LSHIFT || keyCode == Keyboard.KEY_RSHIFT) {
             shiftHeld = true;
         }


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24266
Now the vending machine GUI will not be closed when entering inventory hotkey, which is 'E' in this case, with the searchBar focused.