### PR TITLE
fix no condition trades

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
@@ -204,9 +204,7 @@ public class TradeManager {
 
         boolean enabled = tg.maxTrades == -1 || tradeCount < tg.maxTrades;
 
-        return availableTrades.getOrDefault(player, Collections.emptySet())
-            .contains(tg.getId()) && enabled
-            && cooldownRemaining < 0;
+        return getAvailableTradeGroups(player).contains(tg) && enabled && cooldownRemaining < 0;
     }
 
     public void executeTrade(@Nonnull UUID player, TradeGroup tg) {


### PR DESCRIPTION
In #55, I missed a line when refactoring the tradegroup checking on purchase. This caused no-condition trades to stop working, including the one on zeta. This will fix it.

Tested daily 461 SP+MP