### PR TITLE
Fix VM causing a chunk update every tick

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -593,7 +593,6 @@ public class MTEVendingMachine extends MTEMultiBlockBase
 
     @Override
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
-        super.onPostTick(aBaseMetaTileEntity, aTimer);
         if (aBaseMetaTileEntity.isClientSide()) {
             if (!aBaseMetaTileEntity.isActive()) {
                 OverlayHelper.clearVMOverlay(overlayTickets);


### PR DESCRIPTION
The super call would set active to false and then the VM would set active to true. This caused a chunk update every tick. This PR just gets rid of the super call since it just does a bunch of logic that is not relevant to the VM such as checking maintenance and mufflers.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24622

In MTEMultiBlockBase#onPostTick:
`aBaseMetaTileEntity.setActive(mMaxProgresstime > 0);` (always false)

In MTEVendingMachine#onPostTick:
`aBaseMetaTileEntity.setActive(this.mMachine);`