### PR TITLE
fix nei bookmarks covering the qol buttons and trade tabs

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -201,6 +201,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
 
     public IWidget createQolButtonColumn() {
         return new Grid().left(-17 * 2 + 1)
+            .excludeAreaInRecipeViewer()
             .top(1)
             .minElementMargin(1)
             .coverChildren()
@@ -271,6 +272,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
 
     public IWidget createCategoryTabs(PagedWidget.Controller tabController) {
         Flow tabColumn = Flow.column()
+            .excludeAreaInRecipeViewer()
             .width(40)
             .height(300)
             .left(-29)


### PR DESCRIPTION
Added exclusion area to the qol buttons and the tabs, like so:

<img width="659" height="722" alt="image" src="https://github.com/user-attachments/assets/9a6e9d8a-34b1-40c8-a57e-858b5c2e488d" />

Fixes #104 
