### PR TITLE
Reset color state in TradeItemDisplayWidget

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/TradeItemDisplayWidget.java
@@ -12,6 +12,7 @@ import com.cleanroommc.modularui.drawable.DynamicDrawable;
 import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetThemeEntry;
+import com.cleanroommc.modularui.utils.GlStateManager;
 import com.cleanroommc.modularui.utils.Platform;
 import com.cleanroommc.modularui.value.ObjectValue;
 import com.cleanroommc.modularui.widgets.ItemDisplayWidget;
@@ -92,6 +93,7 @@ public class TradeItemDisplayWidget extends ItemDisplayWidget implements Interac
             if (this.displayType == DisplayType.TILE) {
                 GuiDraw.drawText(" " + this.display.display.stackSize, 4, 9, 1.0f, textColor, false);
                 GuiDraw.drawItem(item, 26, 4, 16, 16, context.getCurrentDrawingZ());
+                GlStateManager.color(1f, 1f, 1f, 1f);
                 if (this.display.isTradeableNow(rootPanel.getWalletMode())) {
                     GuiTextures.OVERLAY_TRADEABLE
                         .draw(0, 0, MTEVendingMachineGui.TILE_ITEM_WIDTH, MTEVendingMachineGui.TILE_ITEM_HEIGHT);


### PR DESCRIPTION
Items with tint (such as spawn eggs) would change the global color state and mess with the colors of other elements. This issue only occurs in tile mode.

Before:
<img width="472" height="187" alt="image" src="https://github.com/user-attachments/assets/0ada9e28-7e32-4a0a-91bf-4a131318d91d" />

After:
<img width="479" height="199" alt="image" src="https://github.com/user-attachments/assets/da103a77-096e-426a-9da8-93efda1a2395" />
