### PR TITLE
Fix music not looping

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/util/VMMusicManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/VMMusicManager.java
@@ -86,6 +86,7 @@ public final class VMMusicManager {
                         .getSoundHandler();
                     soundHandler
                         .playSound(PositionedSoundRecord.func_147673_a(VMConfig.music.current_track.getSoundLoc()));
+                    running = true;
                 }
             }
             return;


### PR DESCRIPTION
When `running` is true, the music manager sets the volume of the music. It wasn't set when we started the music over again so it never had its volume set and would be stuck at 0 until something else adjusted it, such as leaving the VM or changing the volume manually.