### PR TITLE
Scale trade limit with online team member count

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -693,6 +693,11 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
                                 : "vendingmachine.gui.cooldown_idle_tooltip",
                             cur.cooldownText))
                         .style(IKey.DARK_AQUA));
+                builder.addLine(
+                    IKey.str(
+                            Translator.translate(
+                                "vendingmachine.gui.trades_scale_tooltip"))
+                        .style(IKey.DARK_AQUA));
                 builder.emptyLine();
             }
 

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -694,9 +694,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
                             cur.cooldownText))
                         .style(IKey.DARK_AQUA));
                 builder.addLine(
-                    IKey.str(
-                            Translator.translate(
-                                "vendingmachine.gui.trades_scale_tooltip"))
+                    IKey.str(Translator.translate("vendingmachine.gui.trades_scale_tooltip"))
                         .style(IKey.DARK_AQUA));
                 builder.emptyLine();
             }

--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
@@ -138,9 +138,10 @@ public class TradeManager {
         if (player == null) return 0;
         Team team = TeamManager.getTeamByPlayer(player);
         if (team == null) return 0;
-        int teamSize = team.getMembers()
-            .size();
-        return VMConfig.team.maxTradeLimit < 1 ? teamSize : Math.min(VMConfig.team.maxTradeLimit, teamSize);
+
+        int[] count = {0};
+        TeamManager.forEachOnlineTeamMember(team, $ -> count[0]++);
+        return VMConfig.team.maxTradeLimit < 1 ? count[0] : Math.min(VMConfig.team.maxTradeLimit, count[0]);
     }
 
     public void setTradeState(@Nonnull UUID player, TradeGroup tg, TradeHistory history) {

--- a/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/TradeManager.java
@@ -139,7 +139,7 @@ public class TradeManager {
         Team team = TeamManager.getTeamByPlayer(player);
         if (team == null) return 0;
 
-        int[] count = {0};
+        int[] count = { 0 };
         TeamManager.forEachOnlineTeamMember(team, $ -> count[0]++);
         return VMConfig.team.maxTradeLimit < 1 ? count[0] : Math.min(VMConfig.team.maxTradeLimit, count[0]);
     }

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -26,6 +26,7 @@ vendingmachine.gui.shared_trades_tooltip=Shares cooldown with %s other trade(s)
 vendingmachine.gui.cooldown_remaining_tooltip=%s/%s trades remaining
 vendingmachine.gui.cooldown_started_tooltip=Trade limit will reset in %s
 vendingmachine.gui.cooldown_idle_tooltip=Trade limit will reset %s after a trade is made
+vendingmachine.gui.trades_scale_tooltip=Limit scales with online team members
 vendingmachine.gui.trade_hint=Shift-Click to Purchase
 vendingmachine.gui.favourite_hint=Ctrl-Click to Toggle as Favourite
 vendingmachine.gui.display_mode=Display:


### PR DESCRIPTION
Currently the trade limit is based on the total number of team members in the team. This PR changes it so its based on how many team members are online. This bring the balance closer to how it was previously without removing the QoL.

Tested in-game and the limits properly update in real time as team members log on and log off.

This PR was made based on a discussion in #meta-dev https://discord.com/channels/181078474394566657/939305179524792340/1509466147697721404