### PR TITLE
Fix several bugs

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -141,6 +141,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
     private boolean newBufferedOutputs = false;
     private int ticksSinceOutput = 0;
     private int ticksSinceTradeUpdate = 0;
+    public boolean syncTrades = false;
 
     private Map<BigItemStack, Integer> inputSlotCache = new HashMap<>();
 
@@ -587,12 +588,13 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         if (!this.mMachine) return;
         dispenseItems();
         if (
-            this.currentUser != null
-                && this.ticksSinceTradeUpdate++ >= VMConfig.vendingMachineSettings.gui_refresh_interval
+            this.currentUser != null && (this.syncTrades
+                || this.ticksSinceTradeUpdate++ >= VMConfig.vendingMachineSettings.gui_refresh_interval)
         ) {
             if (uplinkHatch != null) uplinkHatch.setRefreshCache();
 
             this.sendTradeUpdate();
+            this.syncTrades = false;
         }
     }
 
@@ -625,8 +627,8 @@ public class MTEVendingMachine extends MTEMultiBlockBase
                     required.stackSize -= slots[i].stackSize;
                     if (!simulate) slots[i] = null;
                 } else {
-                    required.stackSize = 0;
                     if (!simulate) slots[i].stackSize -= required.stackSize;
+                    required.stackSize = 0;
                 }
             }
         }
@@ -672,6 +674,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
                 extractRequiredStackFromSlots(slots, required, stack.getOreDict(), simulate);
             }
 
+            if (required.stackSize == 0) continue;
             BigItemStack requiredBis = stack.copy();
             requiredBis.stackSize = required.stackSize;
             remain.add(requiredBis);

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -6,6 +6,7 @@ import static com.cubefury.vendingmachine.gui.GuiTextures.DISPENSER_OVERHANG;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -16,7 +17,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumChatFormatting;
@@ -63,7 +63,6 @@ import com.cubefury.vendingmachine.blocks.gui.coin.CoinDisplay;
 import com.cubefury.vendingmachine.blocks.gui.fallingitem.FallingItemSlotFactory;
 import com.cubefury.vendingmachine.gui.GuiTextures;
 import com.cubefury.vendingmachine.gui.WidgetThemes;
-import com.cubefury.vendingmachine.network.handlers.NetTradeDisplaySync;
 import com.cubefury.vendingmachine.storage.NameCache;
 import com.cubefury.vendingmachine.trade.CurrencyItem;
 import com.cubefury.vendingmachine.trade.CurrencyType;
@@ -128,6 +127,8 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
     private static final int COIN_COLUMN_WIDTH = 40;
     private static final int COIN_COLUMN_ROW_COUNT = 4;
     private static final String COIN_INSERT_SOUND = "vendingmachine:coin_insert";
+
+    private final List<ItemSlot> inputSlots = new ArrayList<>();
 
     public MTEVendingMachineGui(MTEVendingMachine base) {
         super(base);
@@ -497,9 +498,14 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
 
     private SlotGroupWidget createInputSlots() {
         UUID playerId = NameCache.INSTANCE.getUUIDFromPlayer(getBase().getCurrentUser());
+        this.inputSlots.clear();
         return SlotGroupWidget.builder()
             .matrix("II", "II", "II", "II")
-            .key('I', index -> makeInterceptingSlot(index, playerId))
+            .key('I', index -> {
+                ItemSlot slot = makeInterceptingSlot(index, playerId);
+                inputSlots.add(slot);
+                return slot;
+            })
             .build();
     }
 
@@ -508,41 +514,37 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
         return new ItemSlot().slot(
             slot.slotGroup("inputSlotGroup")
                 .changeListener((newItem, onlyAmountChanged, client, init) -> {
-                    if (client || newItem == null || !base.getActive()) {
+                    if (!base.getActive()) {
                         return;
                     }
                     CurrencyItem currencyItem = CurrencyItem.fromItemStack(newItem);
                     if (currencyItem != null) {
+                        slot.putStack(null);
+                    }
+                    if (client) return;
+                    base.syncTrades = true;
+                    if (currencyItem != null) {
                         Wallet wallet = TradeManager.INSTANCE.getWallet(playerId, walletMode);
                         if (wallet != null) {
                             insertCoin(playerId, currencyItem, wallet);
-                            forceClearSlot(slot);
+                        } else {
+                            base.dispenseItemStacks(Collections.singletonList(newItem));
                         }
+                        forceSyncInputSlots();
                     }
                 }));
+    }
+
+    private void forceSyncInputSlots() {
+        this.inputSlots.forEach(
+            slot -> slot.getSyncHandler()
+                .forceSyncItem());
     }
 
     private void insertCoin(UUID playerId, CurrencyItem currencyItem, @NotNull Wallet wallet) {
         wallet.addCount(currencyItem.type, currencyItem.value);
         base.playSoundEffect(COIN_INSERT_SOUND);
         TradeManager.INSTANCE.saveTeamData(playerId);
-    }
-
-    private void forceClearSlot(ModularSlot slot) {
-        slot.putStack(null);
-        // server-side sync for that input slot
-        // during next tick after any input
-        slot.getSyncHandler()
-            .forceSyncItem();
-        // server side force refresh
-        // Not syncing the trades to client on slot change will cause a short refresh delay, but
-        // might be worth
-        // for huge AE systems
-        NetTradeDisplaySync.syncTradesToClient(
-            (EntityPlayerMP) this.getBase()
-                .getCurrentUser(),
-            this.getBase());
-        base.markDirty();
     }
 
     private IWidget createDispenserChute() {
@@ -886,6 +888,7 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
         UUID playerId = NameCache.INSTANCE.getUUIDFromPlayer(getBase().getCurrentUser());
         for (CurrencyType type : CurrencyType.values()) {
             IntSyncValue coinAmountSyncer = new IntSyncValue(() -> {
+                if (guiData.isClient()) return 0;
                 Wallet wallet = TradeManager.INSTANCE.getWallet(playerId, walletMode);
                 return wallet == null ? 0 : wallet.getCount(type);
             });
@@ -900,14 +903,14 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
             syncManager.syncValue("ejectCoin_" + type.id, ejectCoinSyncer);
         }
 
-        Team team = TeamManager.getTeamByPlayer(playerId);
-        BooleanSyncValue hasTeamSyncer = new BooleanSyncValue(
+        Team team = this.guiData.isClient() ? null : TeamManager.getTeamByPlayer(playerId);
+        BooleanSyncValue hasTeamSyncer = new BooleanSyncValue(() -> false, val -> {
+            walletButtons.setEnabled(val);
+            if (!val) walletMode = WalletMode.PERSONAL;
+        },
             () -> team != null && (VMConfig.team.soloTeam || team.getMembers()
                 .size() > 1),
-            val -> {
-                walletButtons.setEnabled(val);
-                if (!val) walletMode = WalletMode.PERSONAL;
-            });
+            val -> {});
         syncManager.syncValue("hasTeam", hasTeamSyncer);
 
         // Block modifications from server -> client

--- a/src/main/java/com/cubefury/vendingmachine/trade/CurrencyItem.java
+++ b/src/main/java/com/cubefury/vendingmachine/trade/CurrencyItem.java
@@ -58,6 +58,7 @@ public class CurrencyItem {
     }
 
     public static CurrencyItem fromItemStack(ItemStack newItem) {
+        if (newItem == null) return null;
         String itemName = Item.itemRegistry.getNameForObject(newItem.getItem());
         for (CurrencyType type : CurrencyType.values()) {
             if (itemName.startsWith(type.itemPrefix)) {


### PR DESCRIPTION
Fixes all of the following:
1. Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24920 we need to consume the coins on both client and server, then forcesync all input slots from server-side for each inventory change event. Sync is for all input slots since when items are shiftclick+dragged in, a player can easily send in more than one stack per tick, causing ghost stacks to appear in the next free slot.
2. Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24938 When the required item was present, it previously added the same item to the missing items list but with stacksize 0. Then when we checked if missing items list was empty, it would fail. This is fixed.
3. Short delay after putting items in before UI would update. This is because a sync was not scheduled for the next tick after the input slots changed. This is also fixed.
4. GTNHTeam ID missing for player clientside causing some warning messages to appear when opening the UI. This is because the synchandlers and coinvalue init referenced getTeamByPlayer on the client side. Also fixed.
5. Fixed bug where items were not consumed from input slots correctly. This is because I set the requiredItem count to 0, then deducted the count from the input slot amount, instead of the other way round. Also fixed.

Tested Daily 541 SP + MP.