### PR TITLE
show coins in ME system in coin display

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -53,6 +53,7 @@ import com.cubefury.vendingmachine.blocks.gui.WalletMode;
 import com.cubefury.vendingmachine.network.handlers.NetTradeDisplaySync;
 import com.cubefury.vendingmachine.network.handlers.NetTradeRequestSync;
 import com.cubefury.vendingmachine.trade.CurrencyItem;
+import com.cubefury.vendingmachine.trade.CurrencyType;
 import com.cubefury.vendingmachine.trade.Trade;
 import com.cubefury.vendingmachine.trade.TradeDatabase;
 import com.cubefury.vendingmachine.trade.TradeGroup;
@@ -658,6 +659,11 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         }
 
         return success;
+    }
+
+    public int getUplinkCurrencyAmount(CurrencyType type) {
+        if (uplinkHatch == null) return 0;
+        return uplinkHatch.getCurrencyAmount(type);
     }
 
     public List<BigItemStack> removeItems(ItemStack[] slots, List<BigItemStack> fromItems, boolean simulate) {

--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingUplinkHatch.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingUplinkHatch.java
@@ -369,6 +369,10 @@ public class MTEVendingUplinkHatch extends MTEHatch implements IGridProxyable, I
         return consumedItems;
     }
 
+    public int getCurrencyAmount(CurrencyType type) {
+        return meWallet.getCount(type);
+    }
+
     public int removeItem(ItemStack remove, boolean simulate, String ore, Consumer<IAEItemStack> pulledStackTracker) {
         if (remove == null || remove.stackSize == 0) return 0;
         IStorageGrid storage = accessStorage();

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -894,6 +894,11 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
             });
             syncManager.syncValue("coinAmount_" + type.id, coinAmountSyncer);
 
+            syncManager.syncValue("coinAmountMe_" + type.id, new IntSyncValue(() -> {
+                if (guiData.isClient()) return 0;
+                return base.getUplinkCurrencyAmount(type);
+            }));
+
             BooleanSyncValue ejectCoinSyncer = new BooleanSyncValue(() -> this.ejectSingleCoin.get(type), val -> {
                 this.ejectSingleCoin.put(type, val);
                 if (val) {

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/coin/CoinDisplay.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/coin/CoinDisplay.java
@@ -14,6 +14,7 @@ import com.cleanroommc.modularui.widgets.layout.Flow;
 import com.cubefury.vendingmachine.VMConfig;
 import com.cubefury.vendingmachine.blocks.gui.TradeMainPanel;
 import com.cubefury.vendingmachine.trade.CurrencyType;
+import com.cubefury.vendingmachine.util.ColorUtils;
 import com.cubefury.vendingmachine.util.Translator;
 
 public class CoinDisplay extends Flow {
@@ -23,6 +24,7 @@ public class CoinDisplay extends Flow {
     private static final float AMOUNT_SCALE_OFFSET = 0.1f;
 
     private final IntSyncValue coinSyncValue;
+    private final IntSyncValue coinSyncValueMe;
     private final TextWidget<?> coinAmount;
     private final ToggleButton coinButton;
 
@@ -58,6 +60,7 @@ public class CoinDisplay extends Flow {
                 .size(16) };
 
         coinSyncValue = syncManager.findSyncHandler("coinAmount_" + type.id, 0, IntSyncValue.class);
+        coinSyncValueMe = syncManager.findSyncHandler("coinAmountMe_" + type.id, 0, IntSyncValue.class);
         this.child(
             coinButton = new CoinButton(panel, type).overlay(coinIcon1)
                 .size(12)
@@ -65,7 +68,16 @@ public class CoinDisplay extends Flow {
                 .syncHandler("ejectCoin_" + type.id)
                 .tooltipDynamic((builder) -> {
                     builder.clearText();
-                    builder.addLine(coinSyncValue.getValue() + " " + type.getLocalizedName());
+                    StringBuilder valueLine = new StringBuilder().append(coinSyncValue.getValue());
+                    int coinValueMe = coinSyncValueMe.getValue();
+                    valueLine.append(" ");
+                    if (coinValueMe > 0) {
+                        valueLine.append("(+")
+                            .append(coinValueMe)
+                            .append(") ");
+                    }
+                    valueLine.append(type.getLocalizedName());
+                    builder.addLine(valueLine.toString());
                     builder.emptyLine();
                     builder.addLine(
                         IKey.str(Translator.translate("vendingmachine.gui.single_coin_type_eject_hint"))
@@ -73,7 +85,9 @@ public class CoinDisplay extends Flow {
                     builder.setAutoUpdate(true);
                 }))
             .child(
-                coinAmount = IKey.dynamic(() -> getReadableStringFromCoinAmount(coinSyncValue.getValue()))
+                coinAmount = IKey
+                    .dynamic(
+                        () -> getReadableStringFromCoinAmount(coinSyncValue.getValue() + coinSyncValueMe.getValue()))
                     .scale(DEFAULT_AMOUNT_SCALE)
                     .asWidget()
                     .top(3)
@@ -104,21 +118,25 @@ public class CoinDisplay extends Flow {
     @Override
     public void draw(ModularGuiContext context, WidgetThemeEntry<?> widgetTheme) {
         int val = coinSyncValue.getValue();
-        textColor = widgetTheme.getTheme()
-            .getTextColor();
-        if (val == 0) {
+        int valMe = coinSyncValueMe.getValue();
+        textColor = valMe > 0 ? ColorUtils.coinDisplayHasMeCoinsOverride.getColor()
+            : widgetTheme.getTheme()
+                .getTextColor();
+
+        int totalVal = val + valMe;
+        if (totalVal == 0) {
             textColor = Color.lerp(
                 textColor,
                 widgetTheme.getTheme()
                     .getColor(),
                 0.2f);
         }
-        if (val != oldCoinValue) {
+        if (totalVal != oldCoinValue) {
             if (oldCoinValue != -1) {
                 lastCoinChange = System.currentTimeMillis();
-                coinIncreased = val > oldCoinValue;
+                coinIncreased = totalVal > oldCoinValue;
             }
-            oldCoinValue = val;
+            oldCoinValue = totalVal;
             coinButton.overlay(getCoinButtonIcon());
         }
         long now = System.currentTimeMillis();

--- a/src/main/java/com/cubefury/vendingmachine/util/ColorUtils.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/ColorUtils.java
@@ -14,6 +14,7 @@ public class ColorUtils {
         textColorConditionUnsatisfied   = color.rgb("textColorConditionUnsatisfied",    "0xA87A5E"),
         nc_InputsOverlay                = color.rgb("nc_InputsOverlay",                 "0xFDD835"),
         tradeDisplayText                = color.rgb("tradeDisplayText",                 "0xFFFFFF"),
+        coinDisplayHasMeCoinsOverride   = color.rgb("coinDisplayHasMeCoinsOverride",    "0x0000AA"),
 
         tradeDisplayDisabled            = color.argb("tradeDisplayDisabled",            "0xBB000000"),
         tradeDisplayListTradableNow     = color.argb("tradeDisplayListTradableNow",     "0x883CFF00"),

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -18,12 +18,12 @@ vendingmachine.vendinguplink.me.and_more_stacks=%sAnd %d more...
 
 # Gui
 vendingmachine.gui.requirementHeader=Requirements:
-vendingmachine.gui.requirement.unknown=Unknown Requirement
+vendingmachine.gui.requirement.unknown=Unknown Requiremente
 vendingmachine.gui.requirement.betterquesting=Quest
 vendingmachine.gui.requirement.betterquesting.missing=Missing Quest
 vendingmachine.gui.item_eject=Eject Items
-vendingmachine.gui.coin_eject=Eject All Coins
-vendingmachine.gui.single_coin_type_eject_hint=Shift-Click to Extract
+vendingmachine.gui.coin_eject=Eject All Coins from Wallet
+vendingmachine.gui.single_coin_type_eject_hint=Shift-Click to Extract Coins from Wallet
 vendingmachine.gui.search=Search
 vendingmachine.gui.required_inputs=Requires:
 vendingmachine.gui.nc_inputs=Requires (Not Consumed):


### PR DESCRIPTION
1. If you have coins in your ME system they are now added to your wallet in the display and it turns blue.
2. Doesn't show the (+ME coin amount) in tooltip if they don't have any coins of that type in there.
3. Surely the player figures out what the x(+y) in the tooltip means if they can get to EV...

<img width="629" height="235" alt="image" src="https://github.com/user-attachments/assets/e3a98447-288d-4412-9f9e-dc9e0f7a7fd9" />

<img width="480" height="130" alt="image" src="https://github.com/user-attachments/assets/aa22fef1-927b-43b4-91bb-8743c8a0e23b" />

<img width="539" height="147" alt="image" src="https://github.com/user-attachments/assets/62cf0c62-aefb-4450-b17d-87c97ad8abff" />

Some other stuff I tried before landing on this:
1. Colouring the ME coins text in the tooltip looked ugly so i did without it. Also the display in the GUI allows arbitrary hexcodes for colour, but the tooltip only lets you use the mc default chat colours.
2. Having a consistent text colour for the ME coins in both the display and the tooltip is hard, since one background is light and the other is dark. I couldn't get it to look good.
3. I tried having separate lines like "Coin Name \n Wallet: x \n ME: y", also looked ugly.
4. I also tried "x in wallet (+y in ME)", also looked ugly.

tested devenv SP and MP