### PR TITLE
Add button to play vending machine music in the world

### DIFF
--- a/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/MTEVendingMachine.java
@@ -52,6 +52,7 @@ import com.cubefury.vendingmachine.blocks.gui.TradeItemDisplay;
 import com.cubefury.vendingmachine.blocks.gui.WalletMode;
 import com.cubefury.vendingmachine.network.handlers.NetTradeDisplaySync;
 import com.cubefury.vendingmachine.network.handlers.NetTradeRequestSync;
+import com.cubefury.vendingmachine.network.handlers.NetWorldMusicSync;
 import com.cubefury.vendingmachine.trade.CurrencyItem;
 import com.cubefury.vendingmachine.trade.CurrencyType;
 import com.cubefury.vendingmachine.trade.Trade;
@@ -62,6 +63,7 @@ import com.cubefury.vendingmachine.trade.TradeRequest;
 import com.cubefury.vendingmachine.util.BigItemStack;
 import com.cubefury.vendingmachine.util.OverlayHelper;
 import com.cubefury.vendingmachine.util.Translator;
+import com.cubefury.vendingmachine.util.VMMusicManager;
 import com.cubefury.vendingmachine.util.Wallet;
 import com.gtnewhorizon.structurelib.StructureLibAPI;
 import com.gtnewhorizon.structurelib.alignment.IAlignment;
@@ -144,6 +146,13 @@ public class MTEVendingMachine extends MTEMultiBlockBase
     private Map<BigItemStack, Integer> inputSlotCache = new HashMap<>();
 
     private EntityPlayer currentUser = null;
+
+    // World music (jukebox mode). Server is source of truth, persisted in NBT.
+    private boolean worldMusicEnabled = false;
+    // Client mirror of the above, set via NetWorldMusicSync.
+    public boolean clientWorldMusicEnabled = false;
+    // Client: whether this machine's GUI is currently open locally (suppresses world sound).
+    public boolean guiOpenLocally = false;
 
     public MTEVendingMachine(final int aID, final String aName, final String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -466,11 +475,13 @@ public class MTEVendingMachine extends MTEMultiBlockBase
             pendingOutputs.appendTag(itemStack.writeToNBT(new NBTTagCompound()));
         }
         aNBT.setTag("outputBuffer", pendingOutputs);
+        aNBT.setBoolean("worldMusic", this.worldMusicEnabled);
     }
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
         super.loadNBTData(aNBT);
+        this.worldMusicEnabled = aNBT.getBoolean("worldMusic");
         boolean loadedLegacyData = false;
 
         NBTTagList pendingOutputs = aNBT.getTagList("outputBuffer", Constants.NBT.TAG_COMPOUND);
@@ -583,6 +594,14 @@ public class MTEVendingMachine extends MTEMultiBlockBase
             if (!aBaseMetaTileEntity.isActive()) {
                 OverlayHelper.clearVMOverlay(overlayTickets);
             }
+            VMMusicManager.updateWorldMusic(
+                aBaseMetaTileEntity.getWorld().provider.dimensionId,
+                aBaseMetaTileEntity.getXCoord(),
+                aBaseMetaTileEntity.getYCoord(),
+                aBaseMetaTileEntity.getZCoord(),
+                this.clientWorldMusicEnabled,
+                this.guiOpenLocally,
+                aBaseMetaTileEntity.isActive());
             return;
         } else if (this.mUpdate++ % STRUCTURE_CHECK_TICKS == 0) {
             this.mMachine = checkMachine(aBaseMetaTileEntity, null);
@@ -706,6 +725,7 @@ public class MTEVendingMachine extends MTEMultiBlockBase
         if (aBaseMetaTileEntity.isClientSide()) {
             StructureLibAPI.queryAlignment((IAlignmentProvider) aBaseMetaTileEntity);
             setTextureOverlay();
+            NetWorldMusicSync.requestState(this);
         }
     }
 
@@ -749,7 +769,12 @@ public class MTEVendingMachine extends MTEMultiBlockBase
     @Override
     public void onRemoval() {
         super.onRemoval();
-        if (getBaseMetaTileEntity().isClientSide()) OverlayHelper.clearVMOverlay(overlayTickets);
+        if (getBaseMetaTileEntity().isClientSide()) {
+            OverlayHelper.clearVMOverlay(overlayTickets);
+            IGregTechTileEntity te = getBaseMetaTileEntity();
+            VMMusicManager
+                .stopWorldMusic(te.getWorld().provider.dimensionId, te.getXCoord(), te.getYCoord(), te.getZCoord());
+        }
     }
 
     @Override
@@ -793,6 +818,22 @@ public class MTEVendingMachine extends MTEMultiBlockBase
 
     public EntityPlayer getCurrentUser() {
         return this.currentUser;
+    }
+
+    public boolean isWorldMusicEnabled() {
+        return this.worldMusicEnabled;
+    }
+
+    public void setWorldMusicEnabled(boolean enabled) {
+        if (this.worldMusicEnabled == enabled) {
+            return;
+        }
+        this.worldMusicEnabled = enabled;
+        IGregTechTileEntity te = getBaseMetaTileEntity();
+        if (te != null && te.isServerSide()) {
+            this.markDirty();
+            NetWorldMusicSync.broadcastState(this);
+        }
     }
 
     public void resetCurrentUser(EntityPlayer aPlayer) {

--- a/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
+++ b/src/main/java/com/cubefury/vendingmachine/blocks/gui/MTEVendingMachineGui.java
@@ -194,7 +194,9 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
             Unit.Measure.PIXEL);
 
         if (syncManager.isClient()) {
+            base.guiOpenLocally = true;
             panel.onCloseAction(() -> {
+                base.guiOpenLocally = false;
                 FavouritesTracker.INSTANCE.saveFavourites();
                 VMMusicManager.stopVendingMachineMusic();
             });
@@ -328,7 +330,19 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
                                         + VMConfig.gui.sort_mode.getLocalizedName());
                                 setForceRefresh();
                             })
-                            .tooltipAutoUpdate(true))));
+                            .tooltipAutoUpdate(true)),
+                    Arrays.asList(
+                        new ToggleButton().size(14)
+                            .overlay(
+                                new DynamicDrawable(
+                                    () -> (base.isWorldMusicEnabled() ? GuiTextures.AUDIO_ON : GuiTextures.AUDIO_OFF)
+                                        .asIcon()
+                                        .size(12)))
+                            .syncHandler("worldMusic")
+                            .tooltipBuilder(t -> t.addLine(IKey.lang("vendingmachine.gui.world_music"))),
+                        // Empty second cell so the grid row matches the others' width (Grid.sanitizeMatrix
+                        // cannot pad fixed-size Arrays.asList rows, ragged rows crash on init).
+                        null)));
     }
 
     public IWidget createCategoryTabs(PagedWidget.Controller tabController) {
@@ -915,6 +929,11 @@ public class MTEVendingMachineGui extends MTEMultiBlockBaseGui<MTEVendingMachine
             }
         }).allowC2S();
         syncManager.syncValue("ejectCoins", ejectCoinsSyncer);
+
+        BooleanSyncValue worldMusicSyncer = new BooleanSyncValue(
+            () -> base.isWorldMusicEnabled(),
+            val -> base.setWorldMusicEnabled(val)).allowC2S();
+        syncManager.syncValue("worldMusic", worldMusicSyncer);
 
         UUID playerId = NameCache.INSTANCE.getUUIDFromPlayer(getBase().getCurrentUser());
         for (CurrencyType type : CurrencyType.values()) {

--- a/src/main/java/com/cubefury/vendingmachine/network/PacketTypeRegistry.java
+++ b/src/main/java/com/cubefury/vendingmachine/network/PacketTypeRegistry.java
@@ -20,6 +20,7 @@ import com.cubefury.vendingmachine.network.handlers.NetTradeDbSync;
 import com.cubefury.vendingmachine.network.handlers.NetTradeDisplaySync;
 import com.cubefury.vendingmachine.network.handlers.NetTradeNotification;
 import com.cubefury.vendingmachine.network.handlers.NetTradeRequestSync;
+import com.cubefury.vendingmachine.network.handlers.NetWorldMusicSync;
 
 public class PacketTypeRegistry implements IPacketRegistry {
 
@@ -37,6 +38,7 @@ public class PacketTypeRegistry implements IPacketRegistry {
         NetBulkSync.registerHandler();
         NetResetVMUser.registerHandler();
         NetTradeNotification.registerHandler();
+        NetWorldMusicSync.registerHandler();
     }
 
     @Override

--- a/src/main/java/com/cubefury/vendingmachine/network/handlers/NetWorldMusicSync.java
+++ b/src/main/java/com/cubefury/vendingmachine/network/handlers/NetWorldMusicSync.java
@@ -1,0 +1,101 @@
+package com.cubefury.vendingmachine.network.handlers;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.common.DimensionManager;
+
+import com.cubefury.vendingmachine.VendingMachine;
+import com.cubefury.vendingmachine.api.network.UnserializedPacket;
+import com.cubefury.vendingmachine.api.util.Tuple2;
+import com.cubefury.vendingmachine.blocks.MTEVendingMachine;
+import com.cubefury.vendingmachine.network.PacketSender;
+import com.cubefury.vendingmachine.network.PacketTypeRegistry;
+
+import cpw.mods.fml.common.network.NetworkRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
+
+public class NetWorldMusicSync {
+
+    private static final ResourceLocation ID_NAME = new ResourceLocation("vendingmachine:worldmusic_sync");
+    private static final int BROADCAST_RADIUS = 64;
+
+    public static void registerHandler() {
+        PacketTypeRegistry.INSTANCE.registerServerHandler(ID_NAME, NetWorldMusicSync::onServer);
+        if (VendingMachine.proxy.isClient()) {
+            PacketTypeRegistry.INSTANCE.registerClientHandler(ID_NAME, NetWorldMusicSync::onClient);
+        }
+    }
+
+    private static NBTTagCompound coords(IGregTechTileEntity te) {
+        NBTTagCompound payload = new NBTTagCompound();
+        payload.setInteger("dim", te.getWorld().provider.dimensionId);
+        payload.setInteger("x", te.getXCoord());
+        payload.setInteger("y", te.getYCoord());
+        payload.setInteger("z", te.getZCoord());
+        return payload;
+    }
+
+    // Client -> server: ask for the current state (sent when a client tile first ticks).
+    public static void requestState(MTEVendingMachine base) {
+        IGregTechTileEntity te = base.getBaseMetaTileEntity();
+        if (te == null) return;
+        NBTTagCompound payload = coords(te);
+        PacketSender.INSTANCE.sendToServer(new UnserializedPacket(ID_NAME, payload));
+    }
+
+    // Server -> nearby clients: broadcast the current state (sent when it changes).
+    public static void broadcastState(MTEVendingMachine base) {
+        IGregTechTileEntity te = base.getBaseMetaTileEntity();
+        if (te == null) return;
+        NBTTagCompound payload = coords(te);
+        payload.setBoolean("enabled", base.isWorldMusicEnabled());
+        PacketSender.INSTANCE.sendToAround(
+            new UnserializedPacket(ID_NAME, payload),
+            new NetworkRegistry.TargetPoint(
+                te.getWorld().provider.dimensionId,
+                te.getXCoord() + 0.5,
+                te.getYCoord() + 0.5,
+                te.getZCoord() + 0.5,
+                BROADCAST_RADIUS));
+    }
+
+    public static void onServer(Tuple2<NBTTagCompound, EntityPlayerMP> message) {
+        NBTTagCompound m = message.first();
+        World world = DimensionManager.getWorld(m.getInteger("dim"));
+        if (world == null) return;
+        TileEntity te = world.getTileEntity(m.getInteger("x"), m.getInteger("y"), m.getInteger("z"));
+        if (
+            te instanceof IGregTechTileEntity
+                && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MTEVendingMachine
+        ) {
+            MTEVendingMachine vm = (MTEVendingMachine) ((IGregTechTileEntity) te).getMetaTileEntity();
+            NBTTagCompound payload = new NBTTagCompound();
+            payload.setInteger("dim", m.getInteger("dim"));
+            payload.setInteger("x", m.getInteger("x"));
+            payload.setInteger("y", m.getInteger("y"));
+            payload.setInteger("z", m.getInteger("z"));
+            payload.setBoolean("enabled", vm.isWorldMusicEnabled());
+            PacketSender.INSTANCE.sendToPlayers(new UnserializedPacket(ID_NAME, payload), message.second());
+        }
+    }
+
+    @SideOnly(Side.CLIENT)
+    public static void onClient(NBTTagCompound m) {
+        World world = Minecraft.getMinecraft().theWorld;
+        if (world == null) return;
+        TileEntity te = world.getTileEntity(m.getInteger("x"), m.getInteger("y"), m.getInteger("z"));
+        if (
+            te instanceof IGregTechTileEntity
+                && ((IGregTechTileEntity) te).getMetaTileEntity() instanceof MTEVendingMachine
+        ) {
+            ((MTEVendingMachine) ((IGregTechTileEntity) te).getMetaTileEntity()).clientWorldMusicEnabled = m
+                .getBoolean("enabled");
+        }
+    }
+}

--- a/src/main/java/com/cubefury/vendingmachine/util/VMMusicManager.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/VMMusicManager.java
@@ -1,5 +1,8 @@
 package com.cubefury.vendingmachine.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.ISound;
 import net.minecraft.client.audio.PositionedSoundRecord;
@@ -24,6 +27,9 @@ import paulscode.sound.SoundSystem;
 public final class VMMusicManager {
 
     public static boolean tickingMusic = false;
+
+    // Active world (positional) sounds keyed by "dim:x:y:z".
+    private static final Map<String, ISound> worldSounds = new HashMap<>();
 
     private static final int FADE_TIME = 1000;
 
@@ -139,6 +145,40 @@ public final class VMMusicManager {
             inVm = Minecraft.getMinecraft().currentScreen instanceof GuiContainerWrapper;
         }
         return inVm;
+    }
+
+    private static String worldKey(int dim, int x, int y, int z) {
+        return dim + ":" + x + ":" + y + ":" + z;
+    }
+
+    public static void updateWorldMusic(int dim, int x, int y, int z, boolean enabled, boolean guiOpenLocally,
+        boolean active) {
+        String key = worldKey(dim, x, y, z);
+        boolean shouldPlay = enabled && active && !guiOpenLocally && MusicTrack.LUNCH_BREAK.getSoundLoc() != null;
+        SoundHandler soundHandler = Minecraft.getMinecraft()
+            .getSoundHandler();
+        ISound current = worldSounds.get(key);
+        // Track is looped (repeat=true), so map presence is the source of truth.
+        // We must not rely on isSoundPlaying right after playSound: streamed sounds
+        // load asynchronously and report not-playing for a few ticks, which would
+        // start a second overlapping copy.
+        if (shouldPlay && current == null) {
+            ISound sound = new VMWorldSound(MusicTrack.LUNCH_BREAK.getSoundLoc(), x, y, z);
+            worldSounds.put(key, sound);
+            soundHandler.playSound(sound);
+        } else if (!shouldPlay && current != null) {
+            soundHandler.stopSound(current);
+            worldSounds.remove(key);
+        }
+    }
+
+    public static void stopWorldMusic(int dim, int x, int y, int z) {
+        ISound sound = worldSounds.remove(worldKey(dim, x, y, z));
+        if (sound != null) {
+            Minecraft.getMinecraft()
+                .getSoundHandler()
+                .stopSound(sound);
+        }
     }
 
     public static class AudioContext {

--- a/src/main/java/com/cubefury/vendingmachine/util/VMWorldSound.java
+++ b/src/main/java/com/cubefury/vendingmachine/util/VMWorldSound.java
@@ -1,0 +1,24 @@
+package com.cubefury.vendingmachine.util;
+
+import net.minecraft.client.audio.PositionedSound;
+import net.minecraft.util.ResourceLocation;
+
+import com.cubefury.vendingmachine.VMConfig;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+
+@SideOnly(Side.CLIENT)
+public class VMWorldSound extends PositionedSound {
+
+    public VMWorldSound(ResourceLocation location, int x, int y, int z) {
+        super(location);
+        this.xPosF = x + 0.5F;
+        this.yPosF = y + 0.5F;
+        this.zPosF = z + 0.5F;
+        this.repeat = true;
+        // repeatDelay defaults to 0 and attenuationType defaults to LINEAR in PositionedSound.
+        this.volume = VMConfig.music.music_volume;
+        this.field_147663_c = 1.0F; // pitch
+    }
+}

--- a/src/main/resources/assets/vendingmachine/lang/en_US.lang
+++ b/src/main/resources/assets/vendingmachine/lang/en_US.lang
@@ -46,6 +46,7 @@ vendingmachine.gui.display_wallet_team=Team Wallet
 vendingmachine.gui.display_track=Music:
 vendingmachine.gui.display_track_none=None
 vendingmachine.gui.display_track_lunch_break=Lunch Break by Sol IX
+vendingmachine.gui.world_music=Play music in the world
 vendingmachine.gui.cooldown_display.second=s
 vendingmachine.gui.cooldown_display.minute=m
 vendingmachine.gui.cooldown_display.hour=h


### PR DESCRIPTION
Adds a toggle button in the vending machine GUI that makes the machine play its music out loud in the world like a jukebox, audible to all nearby players within the normal ~16 block range, instead of only when someone has the GUI open.

The enabled state lives on the server side of the MTE and is persisted in NBT, synced to nearby clients via a new `NetWorldMusicSync` packet (broadcast on change, request/response when a client tile loads). Each client plays a looping positional `VMWorldSound` at the machine coords; the sound is suppressed for a player while they have that machine's GUI open so the existing in-GUI track plays as before without doubling. There is only one track right now so the button is just on/off.

Open questions for review: the toggle reuses the existing AUDIO_ON/OFF icons (a dedicated icon would read better), and the hearing radius is the vanilla default with no config. Happy to adjust both.
